### PR TITLE
Added support for the Guid type.

### DIFF
--- a/lib/FilterVisitor.js
+++ b/lib/FilterVisitor.js
@@ -158,6 +158,7 @@ var FilterVisitor = (function () {
             //todo: check if string is actually a valid literal type
             case "string":
             case "Edm.String":
+            case "Edm.Guid":
                 return decodeURIComponent(node.raw).replace(/'/g, '').replace(/\"/g, "");
             case "Edm.DateTimeOffset":
             case "Edm.Date":

--- a/src/FilterVisitor.ts
+++ b/src/FilterVisitor.ts
@@ -195,6 +195,7 @@ export class FilterVisitor implements VisitorMap {
       //todo: check if string is actually a valid literal type
       case "string":
       case "Edm.String":
+      case "Edm.Guid":
         return decodeURIComponent(node.raw).replace(/'/g,'').replace(/\"/g,"");
       case "Edm.DateTimeOffset":
       case "Edm.Date":

--- a/test/filterVisitor.test.js
+++ b/test/filterVisitor.test.js
@@ -38,6 +38,10 @@ describe("inmemory visitor", () => {
       expect(f({A: 3, B: 4})).to.be.true
   })
 
+  it("expression 5.1.1.6.1: A eq 01234567-89ab-cdef-0123-456789abcdef", () => {
+      expect(f({A: '01234567-89ab-cdef-0123-456789abcdef'})).to.be.true;
+  });
+
   it('expression 5.1.1.6.2: ["a","b"]', () => {
       expect(e({A: 3, B: 4})).to.eql(['a','b'])
   })


### PR DESCRIPTION
It seems the Guid type was missing, now simply using it as the primitive string value, can't think of any other matching in JavaScript :).